### PR TITLE
feature/recoverable_signatures

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 Revision history for Bitcoin-Secp256k1
 
 {{$NEXT}}
-
+    [New interface]
+    - Added recoverable signature support
+    - Added methods sign_message_recoverable, verify_message_recoverable, recover_public_key_message and digest equivalents
 0.009 - 2025-11-09
 	- Removed a warning when verifying unnormalized signatures
 

--- a/Secp256k1.xs
+++ b/Secp256k1.xs
@@ -6,9 +6,11 @@
 #include <secp256k1.h>
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_schnorrsig.h>
+#include <secp256k1_recovery.h>
 
 #define CURVE_SIZE 32
 #define SCHNORR_SIGNATURE_SIZE 64
+#define RECOVERABLE_SIGNATURE_SIZE 65
 
 typedef struct {
 	secp256k1_context *ctx;
@@ -18,12 +20,14 @@ typedef struct {
 	unsigned int pubkeys_count;
 	secp256k1_ecdsa_signature *signature;
 	unsigned char *schnorr_signature;
+    secp256k1_ecdsa_recoverable_signature *recoverable_signature;
 } secp256k1_perl;
 
 void secp256k1_perl_replace_pubkey(secp256k1_perl *perl_ctx, secp256k1_pubkey *new_pubkey);
 void secp256k1_perl_replace_xonly_pubkey(secp256k1_perl *perl_ctx, secp256k1_xonly_pubkey *new_pubkey);
 void secp256k1_perl_replace_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_signature *new_signature);
 void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature);
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature);
 
 secp256k1_perl* secp256k1_perl_create()
 {
@@ -34,6 +38,7 @@ secp256k1_perl* secp256k1_perl_create()
 	perl_ctx->xonly_pubkey = NULL;
 	perl_ctx->signature = NULL;
 	perl_ctx->schnorr_signature = NULL;
+    perl_ctx->recoverable_signature = NULL;
 	perl_ctx->pubkeys = NULL;
 	perl_ctx->pubkeys_count = 0;
 	return perl_ctx;
@@ -45,6 +50,7 @@ void secp256k1_perl_clear(secp256k1_perl *perl_ctx)
 	secp256k1_perl_replace_xonly_pubkey(perl_ctx, NULL);
 	secp256k1_perl_replace_signature(perl_ctx, NULL);
 	secp256k1_perl_replace_schnorr_signature(perl_ctx, NULL);
+    secp256k1_perl_replace_recoverable_signature(perl_ctx, NULL);
 
 	if (perl_ctx->pubkeys_count > 0) {
 		int i;
@@ -99,6 +105,15 @@ void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned
 	}
 
 	perl_ctx->schnorr_signature = new_signature;
+}
+
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature)
+{
+	if (perl_ctx->recoverable_signature != NULL) {
+		free(perl_ctx->recoverable_signature);
+	}
+
+	perl_ctx->recoverable_signature = new_signature;
 }
 
 /* HELPERS */
@@ -398,6 +413,40 @@ _signature_schnorr(self, ...)
 	OUTPUT:
 		RETVAL
 
+# Getter / setter for the recoverable signature
+SV*
+_signature_recoverable(self, ...)
+		SV *self
+	CODE:
+		secp256k1_perl *ctx = ctx_from_sv(self);
+		if (items > 1 && SvOK(ST(1))) {
+			SV *new_signature = ST(1);
+			if (SvROK(new_signature)) {
+				croak("signature must not be a reference");
+			}
+
+			size_t signature_size;
+			unsigned char *signature = bytestr_from_sv(new_signature, &signature_size);
+
+			if (signature_size != RECOVERABLE_SIGNATURE_SIZE) {
+				croak("invalid recoverable signature size");
+			}
+
+			secp256k1_ecdsa_recoverable_signature *result_signature = malloc(sizeof *result_signature);
+			memcpy(result_signature, signature, sizeof *result_signature);
+
+			secp256k1_perl_replace_recoverable_signature(ctx, result_signature);
+		}
+
+		if (ctx->recoverable_signature != NULL) {
+			RETVAL = newSVpv((char*) ctx->recoverable_signature, RECOVERABLE_SIGNATURE_SIZE);
+		}
+		else {
+			RETVAL = &PL_sv_undef;
+		}
+	OUTPUT:
+		RETVAL
+
 void
 _push_pubkey(self)
 		SV *self
@@ -625,6 +674,117 @@ _sign_schnorr(self, privkey, message)
 		}
 
 		secp256k1_perl_replace_schnorr_signature(ctx, result_signature);
+
+# Signs a recoverable digest
+void
+_sign_recoverable(self, privkey, message)
+		SV* self
+		SV* privkey
+		SV* message
+	CODE:
+		secp256k1_perl *ctx = ctx_from_sv(self);
+
+		unsigned char *message_str = size_bytestr_from_sv(message, CURVE_SIZE, "digest");
+		unsigned char *seckey_str = size_bytestr_from_sv(privkey, CURVE_SIZE, "private key");
+
+		secp256k1_ecdsa_recoverable_signature *result_signature = malloc(sizeof *result_signature);
+		int result = secp256k1_ecdsa_sign_recoverable(
+			ctx->ctx,
+			result_signature,
+			message_str,
+			seckey_str,
+			NULL,
+			NULL
+		);
+
+		if (!result) {
+			free(result_signature);
+			croak("signing failed (nonce generation problem?)");
+		}
+
+		secp256k1_perl_replace_recoverable_signature(ctx, result_signature);
+
+# Serializes recoverable signature to compact format (64 bytes + recovery_id)
+SV*
+_serialize_compact_recoverable(self, recoverable_signature)
+		SV* self
+		SV* recoverable_signature
+	CODE:
+		secp256k1_perl *ctx = ctx_from_sv(self);
+
+		if (!SvOK(recoverable_signature) || SvROK(recoverable_signature)) {
+			croak("recoverable signature must be defined and not a reference");
+		}
+
+		STRLEN sig_size;
+		unsigned char *sig_data = bytestr_from_sv(recoverable_signature, &sig_size);
+
+		if (sig_size != RECOVERABLE_SIGNATURE_SIZE) {
+			croak("invalid recoverable signature size");
+		}
+
+        secp256k1_ecdsa_recoverable_signature *signature = (secp256k1_ecdsa_recoverable_signature*) sig_data;
+
+		unsigned char signature_data[64];
+		int recovery_id;
+
+		int result = secp256k1_ecdsa_recoverable_signature_serialize_compact(
+			ctx->ctx,
+			signature_data,
+			&recovery_id,
+			signature
+		);
+
+		if (!result) {
+			croak("failed to serialize recoverable signature");
+		}
+
+		HV *return_hash = newHV();
+		hv_stores(return_hash, "signature", newSVpv((char*) signature_data, 64));
+		hv_stores(return_hash, "recovery_id", newSViv(recovery_id));
+
+		RETVAL = newRV_noinc((SV*) return_hash);
+	OUTPUT:
+		RETVAL
+
+# Recover an ECDSA public key from a recoverable signature and message hash
+void
+_recover_pubkey_recoverable(self, recoverable_signature, message_hash)
+		SV* self
+		SV* recoverable_signature
+		SV* message_hash
+	CODE:
+		secp256k1_perl *ctx = ctx_from_sv(self);
+
+		if (!SvOK(recoverable_signature) || SvROK(recoverable_signature)) {
+			croak("recoverable signature must be defined and not a reference");
+		}
+
+		unsigned char *message_str = size_bytestr_from_sv(message_hash, CURVE_SIZE, "message hash");
+
+		STRLEN sig_size;
+		unsigned char *sig_data = bytestr_from_sv(recoverable_signature, &sig_size);
+
+		if (sig_size != RECOVERABLE_SIGNATURE_SIZE) {
+			croak("invalid recoverable signature size");
+		}
+
+		secp256k1_ecdsa_recoverable_signature *signature = (secp256k1_ecdsa_recoverable_signature*) sig_data;
+		secp256k1_pubkey *result_pubkey = malloc(sizeof *result_pubkey);
+
+		int result = secp256k1_ecdsa_recover(
+			ctx->ctx,
+			result_pubkey,
+			signature,
+			message_str
+		);
+
+		if (!result) {
+			free(result_pubkey);
+			croak("failed to recover public key from signature");
+		}
+
+		secp256k1_perl_replace_pubkey(ctx, result_pubkey);
 
 # Checks whether a private key is valid
 SV*

--- a/Secp256k1.xs
+++ b/Secp256k1.xs
@@ -20,15 +20,14 @@ typedef struct {
 	unsigned int pubkeys_count;
 	secp256k1_ecdsa_signature *signature;
 	unsigned char *schnorr_signature;
-	unsigned char *recoverable_signature;
-	int recoverable_signature_recovery_id;
+	secp256k1_ecdsa_recoverable_signature *recoverable_signature;
 } secp256k1_perl;
 
 void secp256k1_perl_replace_pubkey(secp256k1_perl *perl_ctx, secp256k1_pubkey *new_pubkey);
 void secp256k1_perl_replace_xonly_pubkey(secp256k1_perl *perl_ctx, secp256k1_xonly_pubkey *new_pubkey);
 void secp256k1_perl_replace_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_signature *new_signature);
 void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature);
-void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature, int recovery_id);
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature);
 
 secp256k1_perl* secp256k1_perl_create()
 {
@@ -40,7 +39,6 @@ secp256k1_perl* secp256k1_perl_create()
 	perl_ctx->signature = NULL;
 	perl_ctx->schnorr_signature = NULL;
 	perl_ctx->recoverable_signature = NULL;
-	perl_ctx->recoverable_signature_recovery_id = 0;
 	perl_ctx->pubkeys = NULL;
 	perl_ctx->pubkeys_count = 0;
 	return perl_ctx;
@@ -52,7 +50,7 @@ void secp256k1_perl_clear(secp256k1_perl *perl_ctx)
 	secp256k1_perl_replace_xonly_pubkey(perl_ctx, NULL);
 	secp256k1_perl_replace_signature(perl_ctx, NULL);
 	secp256k1_perl_replace_schnorr_signature(perl_ctx, NULL);
-	secp256k1_perl_replace_recoverable_signature(perl_ctx, NULL, 0);
+	secp256k1_perl_replace_recoverable_signature(perl_ctx, NULL);
 
 	if (perl_ctx->pubkeys_count > 0) {
 		int i;
@@ -109,14 +107,13 @@ void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned
 	perl_ctx->schnorr_signature = new_signature;
 }
 
-void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature, int recovery_id)
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature)
 {
 	if (perl_ctx->recoverable_signature != NULL) {
 		free(perl_ctx->recoverable_signature);
 	}
 
 	perl_ctx->recoverable_signature = new_signature;
-	perl_ctx->recoverable_signature_recovery_id = recovery_id;
 }
 
 /* HELPERS */
@@ -450,15 +447,40 @@ _signature_recoverable(self, ...)
 				croak("recovery_id must be 0, 1, 2, or 3");
 			}
 
-			unsigned char *stored_sig_data = malloc(RECOVERABLE_SIGNATURE_SIZE);
-			memcpy(stored_sig_data, sig_data, RECOVERABLE_SIGNATURE_SIZE);
-			secp256k1_perl_replace_recoverable_signature(ctx, stored_sig_data, recovery_id);
+			secp256k1_ecdsa_recoverable_signature *parsed_signature = malloc(sizeof *parsed_signature);
+			int result = secp256k1_ecdsa_recoverable_signature_parse_compact(
+				ctx->ctx,
+				parsed_signature,
+				sig_data,
+				recovery_id
+			);
+
+			if (!result) {
+				free(parsed_signature);
+				croak("failed to parse compact recoverable signature");
+			}
+
+			secp256k1_perl_replace_recoverable_signature(ctx, parsed_signature);
 		}
 
 		if (ctx->recoverable_signature != NULL) {
+			unsigned char signature_data[RECOVERABLE_SIGNATURE_SIZE];
+			int recovery_id;
+
+			int result = secp256k1_ecdsa_recoverable_signature_serialize_compact(
+				ctx->ctx,
+				signature_data,
+				&recovery_id,
+				ctx->recoverable_signature
+			);
+
+			if (!result) {
+				croak("failed to serialize recoverable signature");
+			}
+
 			HV *return_hash = newHV();
-			hv_stores(return_hash, "signature", newSVpvn((char*) ctx->recoverable_signature, RECOVERABLE_SIGNATURE_SIZE));
-			hv_stores(return_hash, "recovery_id", newSViv(ctx->recoverable_signature_recovery_id));
+			hv_stores(return_hash, "signature", newSVpvn((char*) signature_data, RECOVERABLE_SIGNATURE_SIZE));
+			hv_stores(return_hash, "recovery_id", newSViv(recovery_id));
 			RETVAL = newRV_noinc((SV*) return_hash);
 		}
 		else {
@@ -707,10 +729,10 @@ _sign_recoverable(self, privkey, message)
 		unsigned char *message_str = size_bytestr_from_sv(message, CURVE_SIZE, "digest");
 		unsigned char *seckey_str = size_bytestr_from_sv(privkey, CURVE_SIZE, "private key");
 
-		secp256k1_ecdsa_recoverable_signature signature;
+		secp256k1_ecdsa_recoverable_signature *signature = malloc(sizeof *signature);
 		int result = secp256k1_ecdsa_sign_recoverable(
 			ctx->ctx,
-			&signature,
+			signature,
 			message_str,
 			seckey_str,
 			NULL,
@@ -718,25 +740,11 @@ _sign_recoverable(self, privkey, message)
 		);
 
 		if (!result) {
+			free(signature);
 			croak("signing failed (nonce generation problem?)");
 		}
 
-		unsigned char *signature_data = malloc(RECOVERABLE_SIGNATURE_SIZE);
-		int recovery_id;
-
-		result = secp256k1_ecdsa_recoverable_signature_serialize_compact(
-			ctx->ctx,
-			signature_data,
-			&recovery_id,
-			&signature
-		);
-
-		if (!result) {
-			free(signature_data);
-			croak("failed to serialize recoverable signature");
-		}
-
-		secp256k1_perl_replace_recoverable_signature(ctx, signature_data, recovery_id);
+		secp256k1_perl_replace_recoverable_signature(ctx, signature);
 
 # Recover an ECDSA public key from a recoverable signature and message hash
 void
@@ -752,24 +760,12 @@ _recover_pubkey_recoverable(self, message_hash)
 
 		unsigned char *message_str = size_bytestr_from_sv(message_hash, CURVE_SIZE, "message hash");
 
-		secp256k1_ecdsa_recoverable_signature signature;
-		int result = secp256k1_ecdsa_recoverable_signature_parse_compact(
-			ctx->ctx,
-			&signature,
-			ctx->recoverable_signature,
-			ctx->recoverable_signature_recovery_id
-		);
-
-		if (!result) {
-			croak("failed to parse compact recoverable signature");
-		}
-
 		secp256k1_pubkey *result_pubkey = malloc(sizeof *result_pubkey);
 
-		result = secp256k1_ecdsa_recover(
+		int result = secp256k1_ecdsa_recover(
 			ctx->ctx,
 			result_pubkey,
-			&signature,
+			ctx->recoverable_signature,
 			message_str
 		);
 

--- a/Secp256k1.xs
+++ b/Secp256k1.xs
@@ -20,14 +20,15 @@ typedef struct {
 	unsigned int pubkeys_count;
 	secp256k1_ecdsa_signature *signature;
 	unsigned char *schnorr_signature;
-    secp256k1_ecdsa_recoverable_signature *recoverable_signature;
+	unsigned char *recoverable_signature;
+	int recoverable_signature_recovery_id;
 } secp256k1_perl;
 
 void secp256k1_perl_replace_pubkey(secp256k1_perl *perl_ctx, secp256k1_pubkey *new_pubkey);
 void secp256k1_perl_replace_xonly_pubkey(secp256k1_perl *perl_ctx, secp256k1_xonly_pubkey *new_pubkey);
 void secp256k1_perl_replace_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_signature *new_signature);
 void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature);
-void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature);
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature, int recovery_id);
 
 secp256k1_perl* secp256k1_perl_create()
 {
@@ -38,7 +39,8 @@ secp256k1_perl* secp256k1_perl_create()
 	perl_ctx->xonly_pubkey = NULL;
 	perl_ctx->signature = NULL;
 	perl_ctx->schnorr_signature = NULL;
-    perl_ctx->recoverable_signature = NULL;
+	perl_ctx->recoverable_signature = NULL;
+	perl_ctx->recoverable_signature_recovery_id = 0;
 	perl_ctx->pubkeys = NULL;
 	perl_ctx->pubkeys_count = 0;
 	return perl_ctx;
@@ -50,7 +52,7 @@ void secp256k1_perl_clear(secp256k1_perl *perl_ctx)
 	secp256k1_perl_replace_xonly_pubkey(perl_ctx, NULL);
 	secp256k1_perl_replace_signature(perl_ctx, NULL);
 	secp256k1_perl_replace_schnorr_signature(perl_ctx, NULL);
-    secp256k1_perl_replace_recoverable_signature(perl_ctx, NULL);
+	secp256k1_perl_replace_recoverable_signature(perl_ctx, NULL, 0);
 
 	if (perl_ctx->pubkeys_count > 0) {
 		int i;
@@ -107,13 +109,14 @@ void secp256k1_perl_replace_schnorr_signature(secp256k1_perl *perl_ctx, unsigned
 	perl_ctx->schnorr_signature = new_signature;
 }
 
-void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, secp256k1_ecdsa_recoverable_signature *new_signature)
+void secp256k1_perl_replace_recoverable_signature(secp256k1_perl *perl_ctx, unsigned char *new_signature, int recovery_id)
 {
 	if (perl_ctx->recoverable_signature != NULL) {
 		free(perl_ctx->recoverable_signature);
 	}
 
 	perl_ctx->recoverable_signature = new_signature;
+	perl_ctx->recoverable_signature_recovery_id = recovery_id;
 }
 
 /* HELPERS */
@@ -421,25 +424,42 @@ _signature_recoverable(self, ...)
 		secp256k1_perl *ctx = ctx_from_sv(self);
 		if (items > 1 && SvOK(ST(1))) {
 			SV *new_signature = ST(1);
-			if (SvROK(new_signature)) {
-				croak("signature must not be a reference");
+
+			if (!SvOK(new_signature)) {
+				croak("recoverable signature must be defined");
 			}
 
-			size_t signature_size;
-			unsigned char *signature = bytestr_from_sv(new_signature, &signature_size);
-
-			if (signature_size != RECOVERABLE_SIGNATURE_SIZE) {
-				croak("invalid recoverable signature size");
+			// Expect hash ref with signature and recovery_id
+			if (!SvROK(new_signature) || SvTYPE(SvRV(new_signature)) != SVt_PVHV) {
+				croak("recoverable signature must be a hash reference with 'signature' and 'recovery_id' keys");
 			}
 
-			secp256k1_ecdsa_recoverable_signature *result_signature = malloc(sizeof *result_signature);
-			memcpy(result_signature, signature, sizeof *result_signature);
+			HV *sig_hash = (HV*) SvRV(new_signature);
 
-			secp256k1_perl_replace_recoverable_signature(ctx, result_signature);
+			SV **sig_sv = hv_fetchs(sig_hash, "signature", 0);
+			SV **recovery_id_sv = hv_fetchs(sig_hash, "recovery_id", 0);
+
+			if (!sig_sv || !recovery_id_sv) {
+				croak("recoverable signature must contain 'signature' and 'recovery_id' keys");
+			}
+
+			unsigned char *sig_data = size_bytestr_from_sv(*sig_sv, 64, "signature data");
+			int recovery_id = SvIV(*recovery_id_sv);
+
+			if (recovery_id < 0 || recovery_id > 3) {
+				croak("recovery_id must be 0, 1, 2, or 3");
+			}
+
+			unsigned char *stored_sig_data = malloc(64);
+			memcpy(stored_sig_data, sig_data, 64);
+			secp256k1_perl_replace_recoverable_signature(ctx, stored_sig_data, recovery_id);
 		}
 
 		if (ctx->recoverable_signature != NULL) {
-			RETVAL = newSVpv((char*) ctx->recoverable_signature, RECOVERABLE_SIGNATURE_SIZE);
+			HV *return_hash = newHV();
+			hv_stores(return_hash, "signature", newSVpvn((char*) ctx->recoverable_signature, 64));
+			hv_stores(return_hash, "recovery_id", newSViv(ctx->recoverable_signature_recovery_id));
+			RETVAL = newRV_noinc((SV*) return_hash);
 		}
 		else {
 			RETVAL = &PL_sv_undef;
@@ -687,10 +707,10 @@ _sign_recoverable(self, privkey, message)
 		unsigned char *message_str = size_bytestr_from_sv(message, CURVE_SIZE, "digest");
 		unsigned char *seckey_str = size_bytestr_from_sv(privkey, CURVE_SIZE, "private key");
 
-		secp256k1_ecdsa_recoverable_signature *result_signature = malloc(sizeof *result_signature);
+		secp256k1_ecdsa_recoverable_signature signature;
 		int result = secp256k1_ecdsa_sign_recoverable(
 			ctx->ctx,
-			result_signature,
+			&signature,
 			message_str,
 			seckey_str,
 			NULL,
@@ -698,84 +718,58 @@ _sign_recoverable(self, privkey, message)
 		);
 
 		if (!result) {
-			free(result_signature);
 			croak("signing failed (nonce generation problem?)");
 		}
 
-		secp256k1_perl_replace_recoverable_signature(ctx, result_signature);
-
-# Serializes recoverable signature to compact format (64 bytes + recovery_id)
-SV*
-_serialize_compact_recoverable(self, recoverable_signature)
-		SV* self
-		SV* recoverable_signature
-	CODE:
-		secp256k1_perl *ctx = ctx_from_sv(self);
-
-		if (!SvOK(recoverable_signature) || SvROK(recoverable_signature)) {
-			croak("recoverable signature must be defined and not a reference");
-		}
-
-		STRLEN sig_size;
-		unsigned char *sig_data = bytestr_from_sv(recoverable_signature, &sig_size);
-
-		if (sig_size != RECOVERABLE_SIGNATURE_SIZE) {
-			croak("invalid recoverable signature size");
-		}
-
-        secp256k1_ecdsa_recoverable_signature *signature = (secp256k1_ecdsa_recoverable_signature*) sig_data;
-
-		unsigned char signature_data[64];
+		unsigned char *signature_data = malloc(64);
 		int recovery_id;
 
-		int result = secp256k1_ecdsa_recoverable_signature_serialize_compact(
+		result = secp256k1_ecdsa_recoverable_signature_serialize_compact(
 			ctx->ctx,
 			signature_data,
 			&recovery_id,
-			signature
+			&signature
 		);
 
 		if (!result) {
+			free(signature_data);
 			croak("failed to serialize recoverable signature");
 		}
 
-		HV *return_hash = newHV();
-		hv_stores(return_hash, "signature", newSVpv((char*) signature_data, 64));
-		hv_stores(return_hash, "recovery_id", newSViv(recovery_id));
-
-		RETVAL = newRV_noinc((SV*) return_hash);
-	OUTPUT:
-		RETVAL
+		secp256k1_perl_replace_recoverable_signature(ctx, signature_data, recovery_id);
 
 # Recover an ECDSA public key from a recoverable signature and message hash
 void
-_recover_pubkey_recoverable(self, recoverable_signature, message_hash)
+_recover_pubkey_recoverable(self, message_hash)
 		SV* self
-		SV* recoverable_signature
 		SV* message_hash
 	CODE:
 		secp256k1_perl *ctx = ctx_from_sv(self);
 
-		if (!SvOK(recoverable_signature) || SvROK(recoverable_signature)) {
-			croak("recoverable signature must be defined and not a reference");
+		if (ctx->recoverable_signature == NULL) {
+			croak("no recoverable signature available - sign first or set via _signature_recoverable");
 		}
 
 		unsigned char *message_str = size_bytestr_from_sv(message_hash, CURVE_SIZE, "message hash");
 
-		STRLEN sig_size;
-		unsigned char *sig_data = bytestr_from_sv(recoverable_signature, &sig_size);
+		secp256k1_ecdsa_recoverable_signature signature;
+		int result = secp256k1_ecdsa_recoverable_signature_parse_compact(
+			ctx->ctx,
+			&signature,
+			ctx->recoverable_signature,
+			ctx->recoverable_signature_recovery_id
+		);
 
-		if (sig_size != RECOVERABLE_SIGNATURE_SIZE) {
-			croak("invalid recoverable signature size");
+		if (!result) {
+			croak("failed to parse compact recoverable signature");
 		}
 
-		secp256k1_ecdsa_recoverable_signature *signature = (secp256k1_ecdsa_recoverable_signature*) sig_data;
 		secp256k1_pubkey *result_pubkey = malloc(sizeof *result_pubkey);
 
-		int result = secp256k1_ecdsa_recover(
+		result = secp256k1_ecdsa_recover(
 			ctx->ctx,
 			result_pubkey,
-			signature,
+			&signature,
 			message_str
 		);
 

--- a/Secp256k1.xs
+++ b/Secp256k1.xs
@@ -10,7 +10,7 @@
 
 #define CURVE_SIZE 32
 #define SCHNORR_SIGNATURE_SIZE 64
-#define RECOVERABLE_SIGNATURE_SIZE 65
+#define RECOVERABLE_SIGNATURE_SIZE 64
 
 typedef struct {
 	secp256k1_context *ctx;
@@ -443,21 +443,21 @@ _signature_recoverable(self, ...)
 				croak("recoverable signature must contain 'signature' and 'recovery_id' keys");
 			}
 
-			unsigned char *sig_data = size_bytestr_from_sv(*sig_sv, 64, "signature data");
+			unsigned char *sig_data = size_bytestr_from_sv(*sig_sv, RECOVERABLE_SIGNATURE_SIZE, "signature data");
 			int recovery_id = SvIV(*recovery_id_sv);
 
 			if (recovery_id < 0 || recovery_id > 3) {
 				croak("recovery_id must be 0, 1, 2, or 3");
 			}
 
-			unsigned char *stored_sig_data = malloc(64);
-			memcpy(stored_sig_data, sig_data, 64);
+			unsigned char *stored_sig_data = malloc(RECOVERABLE_SIGNATURE_SIZE);
+			memcpy(stored_sig_data, sig_data, RECOVERABLE_SIGNATURE_SIZE);
 			secp256k1_perl_replace_recoverable_signature(ctx, stored_sig_data, recovery_id);
 		}
 
 		if (ctx->recoverable_signature != NULL) {
 			HV *return_hash = newHV();
-			hv_stores(return_hash, "signature", newSVpvn((char*) ctx->recoverable_signature, 64));
+			hv_stores(return_hash, "signature", newSVpvn((char*) ctx->recoverable_signature, RECOVERABLE_SIGNATURE_SIZE));
 			hv_stores(return_hash, "recovery_id", newSViv(ctx->recoverable_signature_recovery_id));
 			RETVAL = newRV_noinc((SV*) return_hash);
 		}
@@ -721,7 +721,7 @@ _sign_recoverable(self, privkey, message)
 			croak("signing failed (nonce generation problem?)");
 		}
 
-		unsigned char *signature_data = malloc(64);
+		unsigned char *signature_data = malloc(RECOVERABLE_SIGNATURE_SIZE);
 		int recovery_id;
 
 		result = secp256k1_ecdsa_recoverable_signature_serialize_compact(

--- a/lib/Bitcoin/Secp256k1.pm
+++ b/lib/Bitcoin/Secp256k1.pm
@@ -142,7 +142,7 @@ sub sign_digest_recoverable
 	return $self->_signature_recoverable;
 }
 
-sub recover_public_key
+sub recover_public_key_digest
 {
 	my ($self, $recoverable_signature, $digest) = @_;
 
@@ -155,7 +155,7 @@ sub recover_public_key_message
 {
 	my ($self, $recoverable_signature, $message) = @_;
 
-	return $self->recover_public_key($recoverable_signature, sha256(sha256($message)));
+	return $self->recover_public_key_digest($recoverable_signature, sha256(sha256($message)));
 }
 
 sub verify_message
@@ -481,9 +481,9 @@ Because of that, C<$message_digest> must be a bytestring of length C<32>.
 
 Returns the same hash reference format as L</sign_message_recoverable>.
 
-=head3 recover_public_key
+=head3 recover_public_key_digest
 
-	$public_key = $secp256k1->recover_public_key($recoverable_signature, $message_digest)
+	$public_key = $secp256k1->recover_public_key_digest($recoverable_signature, $message_digest)
 
 Recovers the public key from a recoverable signature and message digest.
 Takes a C<$recoverable_signature> (hash reference as returned by signing methods) and
@@ -498,7 +498,7 @@ the public key separately.
 
 	$public_key = $secp256k1->recover_public_key_message($recoverable_signature, $message)
 
-Same as L</recover_public_key>, but performs double SHA256 on C<$message> first.
+Same as L</recover_public_key_digest>, but performs double SHA256 on C<$message> first.
 C<$message> may be a bytestring of any length.
 
 =head3 verify_message

--- a/lib/Bitcoin/Secp256k1.pm
+++ b/lib/Bitcoin/Secp256k1.pm
@@ -142,18 +142,12 @@ sub sign_digest_recoverable
 	return $self->_signature_recoverable;
 }
 
-sub serialize_compact_recoverable
-{
-	my ($self, $recoverable_signature) = @_;
-
-	return $self->_serialize_compact_recoverable($recoverable_signature);
-}
-
 sub recover_public_key
 {
 	my ($self, $recoverable_signature, $digest) = @_;
 
-	$self->_recover_pubkey_recoverable($recoverable_signature, $digest);
+	$self->_signature_recoverable($recoverable_signature);
+	$self->_recover_pubkey_recoverable($digest);
 	return $self->_pubkey;
 }
 
@@ -210,7 +204,8 @@ sub verify_digest_recoverable
 {
 	my ($self, $public_key, $signature, $digest) = @_;
 
-	$self->_recover_pubkey_recoverable($signature, $digest);
+	$self->_signature_recoverable($signature);
+	$self->_recover_pubkey_recoverable($digest);
 	my $recovered_pubkey = $self->_pubkey;
 
 	return $recovered_pubkey eq $public_key;
@@ -319,7 +314,6 @@ Bitcoin::Secp256k1 - Perl interface to libsecp256k1
 
 	# Recoverable signatures (used in Ethereum)
 	my $recoverable_signature = $secp256k1->sign_message_recoverable($private_key, $message);
-	my $compact_data = $secp256k1->serialize_compact_recoverable($recoverable_signature);
 	my $recovered_pubkey = $secp256k1->recover_public_key_message($recoverable_signature, $message);
 	my $valid = $secp256k1->verify_message_recoverable($public_key, $recoverable_signature, $message);
 
@@ -441,10 +435,20 @@ C<32>.
 
 Signs C<$message>, which may be a bytestring of any length, with
 C<$private_key>, which must be a bytestring of length C<32>. Returns
-a recoverable C<$signature> as a bytestring.
+a hash reference containing the recoverable signature.
 
 C<$message> is first hashed with double SHA256 (known an HASH256 in Bitcoin)
 before passing it to signing algorithm (which expects length C<32> bytestrings).
+
+The returned hash reference contains:
+
+=over
+
+=item C<signature> - 64 bytes containing r (32 bytes) and s (32 bytes) values
+
+=item C<recovery_id> - Integer from 0 to 3 indicating which recovery method to use
+
+=back
 
 Recoverable signatures allow the public key to be recovered from the signature
 and message, which is useful for systems like Ethereum where only the signature
@@ -475,30 +479,14 @@ C<$message_digest> to be a bytestring of length C<32>.
 Same as L</sign_message_recoverable>, but it does not perform double SHA256 on its input.
 Because of that, C<$message_digest> must be a bytestring of length C<32>.
 
-=head3 serialize_compact_recoverable
-
-	$compact_data = $secp256k1->serialize_compact_recoverable($recoverable_signature)
-
-Serializes a recoverable signature into compact format. Takes a C<$recoverable_signature>
-(as returned by signing methods) and returns a hash reference containing:
-
-=over
-
-=item C<signature> - 64 bytes containing r (32 bytes) and s (32 bytes) values
-
-=item C<recovery_id> - Integer from 0 to 3 indicating which recovery method to use
-
-=back
-
-This format is commonly used in Ethereum transactions where the signature is
-represented as r, s, v (where v = recovery_id + 27 for legacy transactions).
+Returns the same hash reference format as L</sign_message_recoverable>.
 
 =head3 recover_public_key
 
 	$public_key = $secp256k1->recover_public_key($recoverable_signature, $message_digest)
 
 Recovers the public key from a recoverable signature and message digest.
-Takes a C<$recoverable_signature> (as returned by signing methods) and
+Takes a C<$recoverable_signature> (hash reference as returned by signing methods) and
 C<$message_digest> (bytestring of length C<32>). Returns the recovered
 public key in compressed form.
 
@@ -544,7 +532,7 @@ algorithm.
 
 	$valid = $secp256k1->verify_message_recoverable($public_key, $signature, $message)
 
-Verifies a recoverable C<$signature> of C<$message> (bytestring of any length)
+Verifies a recoverable C<$signature> (hash reference as returned by signing methods) of C<$message> (bytestring of any length)
 against C<$public_key> (compressed or uncompressed, bytestring). Returns true
 if verification is successful.
 

--- a/lib/Bitcoin/Secp256k1.pm
+++ b/lib/Bitcoin/Secp256k1.pm
@@ -111,6 +111,13 @@ sub sign_message_schnorr
 	return $self->sign_digest_schnorr($private_key, sha256($message));
 }
 
+sub sign_message_recoverable
+{
+	my ($self, $private_key, $message) = @_;
+
+	return $self->sign_digest_recoverable($private_key, sha256(sha256($message)));
+}
+
 sub sign_digest
 {
 	my ($self, $private_key, $digest) = @_;
@@ -127,6 +134,36 @@ sub sign_digest_schnorr
 	return $self->_signature_schnorr;
 }
 
+sub sign_digest_recoverable
+{
+	my ($self, $private_key, $digest) = @_;
+
+	$self->_sign_recoverable($private_key, $digest);
+	return $self->_signature_recoverable;
+}
+
+sub serialize_compact_recoverable
+{
+	my ($self, $recoverable_signature) = @_;
+
+	return $self->_serialize_compact_recoverable($recoverable_signature);
+}
+
+sub recover_public_key
+{
+	my ($self, $recoverable_signature, $digest) = @_;
+
+	$self->_recover_pubkey_recoverable($recoverable_signature, $digest);
+	return $self->_pubkey;
+}
+
+sub recover_public_key_message
+{
+	my ($self, $recoverable_signature, $message) = @_;
+
+	return $self->recover_public_key($recoverable_signature, sha256(sha256($message)));
+}
+
 sub verify_message
 {
 	my ($self, $public_key, $signature, $message) = @_;
@@ -139,6 +176,13 @@ sub verify_message_schnorr
 	my ($self, $public_key, $signature, $message) = @_;
 
 	return $self->verify_digest_schnorr($public_key, $signature, sha256($message));
+}
+
+sub verify_message_recoverable
+{
+	my ($self, $public_key, $signature, $message) = @_;
+
+	return $self->verify_digest_recoverable($public_key, $signature, sha256(sha256($message)));
 }
 
 sub verify_digest
@@ -160,6 +204,16 @@ sub verify_digest_schnorr
 	$self->_signature_schnorr($signature);
 
 	return $self->_verify_schnorr($digest);
+}
+
+sub verify_digest_recoverable
+{
+	my ($self, $public_key, $signature, $digest) = @_;
+
+	$self->_recover_pubkey_recoverable($signature, $digest);
+	my $recovered_pubkey = $self->_pubkey;
+
+	return $recovered_pubkey eq $public_key;
 }
 
 sub negate_public_key
@@ -262,6 +316,12 @@ Bitcoin::Secp256k1 - Perl interface to libsecp256k1
 	my $schnorr_signature = $secp256k1->sign_message_schnorr($private_key, $message);
 	my $xonly_public_key = $secp256k1->xonly_public_key($public_key);
 	my $valid = $secp256k1->verify_message_schnorr($xonly_public_key, $schnorr_signature, $message);
+
+	# Recoverable signatures (used in Ethereum)
+	my $recoverable_signature = $secp256k1->sign_message_recoverable($private_key, $message);
+	my $compact_data = $secp256k1->serialize_compact_recoverable($recoverable_signature);
+	my $recovered_pubkey = $secp256k1->recover_public_key_message($recoverable_signature, $message);
+	my $valid = $secp256k1->verify_message_recoverable($public_key, $recoverable_signature, $message);
 
 =head1 DESCRIPTION
 
@@ -375,6 +435,24 @@ value to be used instead by setting package variable
 C<$Bitcoin::Secp256k1::FORCED_SCHNORR_AUX_RAND> to any bytestring of length
 C<32>.
 
+=head3 sign_message_recoverable
+
+	$signature = $secp256k1->sign_message_recoverable($private_key, $message)
+
+Signs C<$message>, which may be a bytestring of any length, with
+C<$private_key>, which must be a bytestring of length C<32>. Returns
+a recoverable C<$signature> as a bytestring.
+
+C<$message> is first hashed with double SHA256 (known an HASH256 in Bitcoin)
+before passing it to signing algorithm (which expects length C<32> bytestrings).
+
+Recoverable signatures allow the public key to be recovered from the signature
+and message, which is useful for systems like Ethereum where only the signature
+is stored in transactions.
+
+This method always produces deterministic signatures suitable for use in
+recoverable signature systems.
+
 =head3 sign_digest
 
 	$signature = $secp256k1->sign_digest($private_key, $message_digest)
@@ -389,6 +467,51 @@ Because of that, C<$message_digest> must be a bytestring of length C<32>.
 Same as L</sign_message_schnorr>, but it does not perform SHA256 on its input.
 While Schnorr allows any length message, this method requires
 C<$message_digest> to be a bytestring of length C<32>.
+
+=head3 sign_digest_recoverable
+
+	$signature = $secp256k1->sign_digest_recoverable($private_key, $message_digest)
+
+Same as L</sign_message_recoverable>, but it does not perform double SHA256 on its input.
+Because of that, C<$message_digest> must be a bytestring of length C<32>.
+
+=head3 serialize_compact_recoverable
+
+	$compact_data = $secp256k1->serialize_compact_recoverable($recoverable_signature)
+
+Serializes a recoverable signature into compact format. Takes a C<$recoverable_signature>
+(as returned by signing methods) and returns a hash reference containing:
+
+=over
+
+=item C<signature> - 64 bytes containing r (32 bytes) and s (32 bytes) values
+
+=item C<recovery_id> - Integer from 0 to 3 indicating which recovery method to use
+
+=back
+
+This format is commonly used in Ethereum transactions where the signature is
+represented as r, s, v (where v = recovery_id + 27 for legacy transactions).
+
+=head3 recover_public_key
+
+	$public_key = $secp256k1->recover_public_key($recoverable_signature, $message_digest)
+
+Recovers the public key from a recoverable signature and message digest.
+Takes a C<$recoverable_signature> (as returned by signing methods) and
+C<$message_digest> (bytestring of length C<32>). Returns the recovered
+public key in compressed form.
+
+This is the core functionality that makes recoverable signatures useful -
+it allows determining which public key created a signature without storing
+the public key separately.
+
+=head3 recover_public_key_message
+
+	$public_key = $secp256k1->recover_public_key_message($recoverable_signature, $message)
+
+Same as L</recover_public_key>, but performs double SHA256 on C<$message> first.
+C<$message> may be a bytestring of any length.
 
 =head3 verify_message
 
@@ -417,6 +540,19 @@ is successful.
 C<$message> is first hashed with SHA256 before passing it to verification
 algorithm.
 
+=head3 verify_message_recoverable
+
+	$valid = $secp256k1->verify_message_recoverable($public_key, $signature, $message)
+
+Verifies a recoverable C<$signature> of C<$message> (bytestring of any length)
+against C<$public_key> (compressed or uncompressed, bytestring). Returns true
+if verification is successful.
+
+C<$message> is first hashed with double SHA256 before verification.
+
+This method works by recovering the public key from the signature and comparing
+it to the provided public key.
+
 =head3 verify_digest
 
 	$valid = $secp256k1->verify_digest($public_key, $signature, $message_digest)
@@ -431,6 +567,13 @@ Because of that, C<$message_digest> must be a bytestring of length C<32>.
 Same as L</verify_message_schnorr>, but it does not perform SHA256 on its
 input. While Schnorr allows any length message, this method requires
 C<$message_digest> to be a bytestring of length C<32>.
+
+=head3 verify_digest_recoverable
+
+	$valid = $secp256k1->verify_digest_recoverable($public_key, $signature, $message_digest)
+
+Same as L</verify_message_recoverable>, but it does not perform double SHA256 on its input.
+Because of that, C<$message_digest> must be a bytestring of length C<32>.
 
 =head3 xonly_public_key
 
@@ -525,10 +668,10 @@ documentation for details.
 
 =head2 TODO
 
-This module currently covers most usage paths of the base libsecp256k1 and the
-Schnorr module. It currently does not aim to cover every usage path, most
-notably signing variable length messages with Schnorr (without digesting
-first).
+This module currently covers most usage paths of the base libsecp256k1, the
+Schnorr module, and the recovery module. It currently does not aim to cover
+every usage path, most notably signing variable length messages with Schnorr
+(without digesting first).
 
 =head1 CAVEATS
 

--- a/t/api.t
+++ b/t/api.t
@@ -121,12 +121,10 @@ subtest 'should sign and verify a message (recoverable)' => sub {
 	my $rec_sig = $secp->sign_message_recoverable($t{privkey}, $t{preimage});
 	ok defined($rec_sig), 'recoverable message signed ok';
 
-	# Test serialize compact
-	my $result = $secp->serialize_compact_recoverable($rec_sig);
-	ok defined($result->{signature}), 'compact signature extracted ok';
-	ok defined($result->{recovery_id}), 'recovery id extracted ok';
-	is length($result->{signature}), 64, 'compact signature length ok';
-	ok $result->{recovery_id} >= 0 && $result->{recovery_id} <= 3, 'recovery id range ok';
+	ok defined($rec_sig->{signature}), 'compact signature extracted ok';
+	ok defined($rec_sig->{recovery_id}), 'recovery id extracted ok';
+	is length($rec_sig->{signature}), 64, 'compact signature length ok';
+	ok $rec_sig->{recovery_id} >= 0 && $rec_sig->{recovery_id} <= 3, 'recovery id range ok';
 
 	# Test recovery
 	my $recovered_pubkey = $secp->recover_public_key_message($rec_sig, $t{preimage});
@@ -160,8 +158,9 @@ subtest 'should sign and verify a digest (recoverable)' => sub {
 		'wrong digest verification fails ok';
 };
 
+# https://ethereum.github.io/yellowpaper/paper.pdf
+# Appendix F. Signing Transactions
 subtest 'ethereum yellowpaper specification' => sub {
-
 	my @test_cases = (
 		{
 			name => 'pk1 recoverable case',
@@ -178,15 +177,9 @@ subtest 'ethereum yellowpaper specification' => sub {
 	for my $case (@test_cases) {
 		subtest $case->{name} => sub {
 			my $rec_sig = $secp->sign_digest_recoverable($case->{privkey}, $case->{message});
-			my $compact = $secp->serialize_compact_recoverable($rec_sig);
 
-			# Extract components as per yellowpaper
-			my $r = substr($compact->{signature}, 0, 32);
-			my $s = substr($compact->{signature}, 32, 32);
-			my $v = $compact->{recovery_id};
-
-			# Yellowpaper constraints
-			# v ∈ {0, 1}
+			# Yellowpaper constraint: v ∈ {0, 1}
+			my $v = $rec_sig->{recovery_id};
 			ok $v >= 0 && $v <= 1, 'v in valid range [0,1]';
 
 			# Test recovery

--- a/t/api.t
+++ b/t/api.t
@@ -117,5 +117,90 @@ subtest 'should combine' => sub {
 	is $secp->combine_public_keys($t{pubkey}, @to_combine), $combined_pubkey, 'combined pubkey ok';
 };
 
+subtest 'should sign and verify a message (recoverable)' => sub {
+	my $rec_sig = $secp->sign_message_recoverable($t{privkey}, $t{preimage});
+	ok defined($rec_sig), 'recoverable message signed ok';
+
+	# Test serialize compact
+	my $result = $secp->serialize_compact_recoverable($rec_sig);
+	ok defined($result->{signature}), 'compact signature extracted ok';
+	ok defined($result->{recovery_id}), 'recovery id extracted ok';
+	is length($result->{signature}), 64, 'compact signature length ok';
+	ok $result->{recovery_id} >= 0 && $result->{recovery_id} <= 3, 'recovery id range ok';
+
+	# Test recovery
+	my $recovered_pubkey = $secp->recover_public_key_message($rec_sig, $t{preimage});
+	is $recovered_pubkey, $t{pubkey}, 'public key recovered from message ok';
+
+	# Test verification methods
+	ok $secp->verify_message_recoverable($t{pubkey}, $rec_sig, $t{preimage}), 'recoverable message verified ok';
+
+	# Test with wrong pubkey should fail
+	my $wrong_pubkey = pack 'H*', '025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6358';
+	ok !$secp->verify_message_recoverable($wrong_pubkey, $rec_sig, $t{preimage}),
+		'wrong pubkey verification fails ok';
+};
+
+subtest 'should sign and verify a digest (recoverable)' => sub {
+	my $digest = sha256(sha256($t{preimage}));
+	my $rec_sig = $secp->sign_digest_recoverable($t{privkey}, $digest);
+	ok defined($rec_sig), 'recoverable digest signed ok';
+
+	# Test recovery
+	my $recovered_pubkey = $secp->recover_public_key($rec_sig, $digest);
+	is $recovered_pubkey, $t{pubkey}, 'public key recovered from digest ok';
+
+	# Test verification
+	ok $secp->verify_digest_recoverable($t{pubkey}, $rec_sig, $digest), 'recoverable digest verified ok';
+
+	# Test with bad digest should fail
+	my $bad_digest = $digest;
+	substr($bad_digest, 0, 1) = "\xff";
+	ok !$secp->verify_digest_recoverable($t{pubkey}, $rec_sig, $bad_digest),
+		'wrong digest verification fails ok';
+};
+
+subtest 'ethereum yellowpaper specification' => sub {
+
+	my @test_cases = (
+		{
+			name => 'pk1 recoverable case',
+			privkey => pack('H*', '0000000000000000000000000000000000000000000000000000000000000001'),
+			message => pack('H*', '0000000000000000000000000000000000000000000000000000000000000001'),
+		},
+		{
+			name => 'pk2 recoverable case',
+			privkey => pack('H*', '4646464646464646464646464646464646464646464646464646464646464646'),
+			message => pack('H*', '9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'),
+		},
+	);
+
+	for my $case (@test_cases) {
+		subtest $case->{name} => sub {
+			my $rec_sig = $secp->sign_digest_recoverable($case->{privkey}, $case->{message});
+			my $compact = $secp->serialize_compact_recoverable($rec_sig);
+
+			# Extract components as per yellowpaper
+			my $r = substr($compact->{signature}, 0, 32);
+			my $s = substr($compact->{signature}, 32, 32);
+			my $v = $compact->{recovery_id};
+
+			# Yellowpaper constraints
+			# v ∈ {0, 1}
+			ok $v >= 0 && $v <= 1, 'v in valid range [0,1]';
+
+			# Test recovery
+			my $recovered_pubkey = $secp->recover_public_key($rec_sig, $case->{message});
+			my $original_pubkey = $secp->create_public_key($case->{privkey});
+			is $recovered_pubkey, $original_pubkey, 'recovery matches original';
+
+			# Test message-level recovery
+			my $rec_sig_msg = $secp->sign_message_recoverable($case->{privkey}, $case->{message});
+			my $recovered_pubkey_msg = $secp->recover_public_key_message($rec_sig_msg, $case->{message});
+			is $recovered_pubkey_msg, $original_pubkey, 'message recovery matches original';
+		};
+	}
+};
+
 done_testing;
 

--- a/t/api.t
+++ b/t/api.t
@@ -145,7 +145,7 @@ subtest 'should sign and verify a digest (recoverable)' => sub {
 	ok defined($rec_sig), 'recoverable digest signed ok';
 
 	# Test recovery
-	my $recovered_pubkey = $secp->recover_public_key($rec_sig, $digest);
+	my $recovered_pubkey = $secp->recover_public_key_digest($rec_sig, $digest);
 	is $recovered_pubkey, $t{pubkey}, 'public key recovered from digest ok';
 
 	# Test verification
@@ -183,7 +183,7 @@ subtest 'ethereum yellowpaper specification' => sub {
 			ok $v >= 0 && $v <= 1, 'v in valid range [0,1]';
 
 			# Test recovery
-			my $recovered_pubkey = $secp->recover_public_key($rec_sig, $case->{message});
+			my $recovered_pubkey = $secp->recover_public_key_digest($rec_sig, $case->{message});
 			my $original_pubkey = $secp->create_public_key($case->{privkey});
 			is $recovered_pubkey, $original_pubkey, 'recovery matches original';
 

--- a/xt/author/leaks.t
+++ b/xt/author/leaks.t
@@ -1,5 +1,6 @@
 use Test2::V0;
 use Bitcoin::Secp256k1;
+use Digest::SHA qw(sha256);
 
 use constant HAS_TEST_MEMORYGROWTH => eval { require Test::MemoryGrowth; 1 };
 plan skip_all => 'This test requires Test::MemoryGrowth module'
@@ -15,8 +16,8 @@ my $message = 'a quick brown fox jumped over a lazy dog';
 Test::MemoryGrowth::no_growth {
 	my $secp = Bitcoin::Secp256k1->new;
 
-	my $public_key = $secp->create_public_key($private_key);
-	$public_key = $secp->compress_public_key($public_key, !!0);
+	my $compressed_public_key = $secp->create_public_key($private_key);
+	my $public_key = $secp->compress_public_key($compressed_public_key, !!0);
 
 	my $result = eval {
 		$secp->combine_public_keys($public_key, "\x02" . "\xff" x 32);
@@ -30,6 +31,18 @@ Test::MemoryGrowth::no_growth {
 	my $schnorr_signature = $secp->sign_message_schnorr($private_key, $message);
 	my $xonly_pubkey = $secp->xonly_public_key($public_key);
 	die 'invalid sig?' unless $secp->verify_message_schnorr($xonly_pubkey, $schnorr_signature, $message);
+
+	# Test recoverable signatures
+	my $recoverable_signature = $secp->sign_message_recoverable($private_key, $message);
+	die 'invalid recoverable sig?'
+		unless defined $recoverable_signature->{signature} && defined $recoverable_signature->{recovery_id};
+
+	my $digest = sha256(sha256($message));
+	my $recovered_pubkey = $secp->recover_public_key_digest($recoverable_signature, $digest);
+	die 'recovery failed?' unless $recovered_pubkey eq $compressed_public_key;
+
+	die 'invalid recoverable verification?'
+		unless $secp->verify_message_recoverable($compressed_public_key, $recoverable_signature, $message);
 }
 calls => 1000, 'construction/destruction of Bitcoin::Secp256k1 does not leak';
 


### PR DESCRIPTION
Implements https://github.com/Perl-Bitcoin/Bitcoin-Secp256k1/issues/3

Adds recoverable signatures support:

New methods:

`sign_digest_recoverable`
~~`serialize_compact_recoverable`~~
`recover_public_key`
`recover_public_key_message`
`verify_message_recoverable`
`verify_digest_recoverable`

Usage:
```perl
my $recoverable_signature = $secp256k1->sign_message_recoverable($private_key, $message);

# (removed) my $compact_data = $secp256k1->serialize_compact_recoverable($recoverable_signature);

my $signature = $recoverable_signature->{signature};
my $recover_id = $recoverable_signature->{recovery_id};

my $recovered_pubkey = $secp256k1->recover_public_key_message($recoverable_signature, $message);
my $valid = $secp256k1->verify_message_recoverable($public_key, $recoverable_signature, $message);
```

This PR depends on https://github.com/Perl-Bitcoin/Alien-libsecp256k1/pull/1